### PR TITLE
大佬，发现您的项目引入了com.fasterxml.jackson.core:jackson-databind@2.9.7组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.yibi</groupId>
@@ -28,7 +28,7 @@
         <lombok.version>1.18.16</lombok.version>
         <kotlin-stdlib.version>1.3.70</kotlin-stdlib.version>
         <web3sdk.version>2.6.1</web3sdk.version>
-        <jackson.version>2.9.7</jackson.version>
+        <jackson.version>2.9.10.8</jackson.version>
         <okhttp.version>4.8.1</okhttp.version>
         <bcprov-jdk15on.version>1.67</bcprov-jdk15on.version>
         <commons-io.version>2.6</commons-io.version>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：FasterXML jackson-databind反序列化漏洞(AnterosDBCPConfig gadget绕过)
缺陷组件：com.fasterxml.jackson.core:jackson-databind@2.9.7
漏洞编号：CVE-2020-9548
漏洞描述：FasterXML Jackson是美国FasterXML公司的一款适用于Java的数据处理工具。jackson-databind是其中的一个具有数据绑定功能的组件。
FasterXML jackson-databind 2.9.10.4之前的2.x版本中存在安全漏洞。攻击者可借助特制的请求利用该漏洞执行任意代码。
影响范围：[2.9.0, 2.9.10.4)
最小修复版本：2.9.10.8
缺陷组件引入路径：com.yibi:evidence-chain-demo@1.0.1->com.fasterxml.jackson.core:jackson-databind@2.9.7
```
另外我运行这个项目时，IDE的安全插件提示还有83个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p8c3ad